### PR TITLE
feat(lint): show syntax errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -325,6 +325,16 @@
         "style-mod": "^4.0.0"
       }
     },
+    "@codemirror/lint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.0.0.tgz",
+      "integrity": "sha512-nUUXcJW1Xp54kNs+a1ToPLK8MadO0rMTnJB8Zk4Z8gBdrN0kqV7uvUraU/T2yqg+grDNR38Vmy/MrhQN/RgwiA==",
+      "requires": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
     "@codemirror/state": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.0.0.tgz",
@@ -1489,6 +1499,11 @@
         "object-assign": "^4",
         "vary": "^1"
       }
+    },
+    "crelt": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
+      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
     },
     "cross-env": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "license": "MIT",
   "dependencies": {
     "@codemirror/language": "^6.0.0",
+    "@codemirror/lint": "^6.0.0",
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
     "@lezer/highlight": "^1.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
 import { language } from './language';
+import linter from './lint';
 import theme from './theme';
 
 /**
@@ -40,7 +41,8 @@ export default function FeelEditor({
         changeHandler,
         keyHandler,
         language(),
-        theme
+        theme,
+        linter
       ]
     }),
     parent: container

--- a/src/lint/index.js
+++ b/src/lint/index.js
@@ -1,0 +1,3 @@
+import syntaxLinter from './syntax';
+
+export default [ syntaxLinter ];

--- a/src/lint/syntax.js
+++ b/src/lint/syntax.js
@@ -1,0 +1,42 @@
+import { syntaxTree } from '@codemirror/language';
+import { linter } from '@codemirror/lint';
+
+export const FeelLinter = function(editorView) {
+  const messages = [];
+  const tree = syntaxTree(editorView.state);
+
+  tree.iterate({
+    enter: node => {
+      if (node.type.isError) {
+
+        const error = node.toString();
+
+        /* The error has the pattern [⚠ || ⚠(NodeType)]. The regex extracts the node type from inside the brackets */
+        const match = /\((.*?)\)/.exec(error);
+        const nodeType = match && match[1];
+
+        let message;
+
+        if (nodeType) {
+          message = 'unexpected ' + nodeType;
+        } else {
+          message = 'expression expected';
+        }
+
+        messages.push(
+          {
+            from: node.from,
+            to: node.to,
+            severity: 'error',
+            message: message,
+            source: 'syntaxError'
+          }
+        );
+      }
+    }
+  });
+
+  return messages;
+};
+
+export default linter(FeelLinter);

--- a/test/spec/CodeEditor.spec.js
+++ b/test/spec/CodeEditor.spec.js
@@ -1,6 +1,7 @@
 import FeelEditor from '../../src';
 import TestContainer from 'mocha-test-container-support';
 import { EditorSelection } from '@codemirror/state';
+import { diagnosticCount, forceLinting } from '@codemirror/lint';
 
 
 const singleStart = window.__env__ && window.__env__.SINGLE_START;
@@ -160,6 +161,57 @@ return
       // then
       expect(onKeyDown).to.have.been.calledOnce;
       expect(onKeyDown).to.have.been.calledWith(event);
+    });
+
+  });
+
+
+  describe('lint', function() {
+
+    it('should highlight unexpected operations', function(done) {
+      const initalValue = '= 15';
+
+      const editor = new FeelEditor({
+        container,
+        value: initalValue
+      });
+
+      const cm = editor._cmEditor;
+
+      // when
+      forceLinting(cm);
+
+
+      // then
+      // update done async
+      setTimeout(() => {
+        expect(diagnosticCount(cm.state)).to.eql(1);
+        done();
+      }, 0);
+
+    });
+
+
+    it('should highlight missing operations', function(done) {
+      const initalValue = '15 == 15';
+
+      const editor = new FeelEditor({
+        container,
+        value: initalValue
+      });
+
+      const cm = editor._cmEditor;
+
+      // when
+      forceLinting(cm);
+
+      // then
+      // update done async
+      setTimeout(() => {
+        expect(diagnosticCount(cm.state)).to.eql(1);
+        done();
+      }, 0);
+
     });
 
   });

--- a/test/spec/lint/syntax.spec.js
+++ b/test/spec/lint/syntax.spec.js
@@ -1,0 +1,55 @@
+import FeelEditor from '../../../src';
+import TestContainer from 'mocha-test-container-support';
+import { FeelLinter } from '../../../src/lint/syntax';
+
+describe('lint - Syntax', function() {
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  it('should return syntax error', function() {
+
+    // given
+    const editor = new FeelEditor({
+      container,
+      value: '= 12'
+    });
+
+    const cm = editor._cmEditor;
+
+    // when
+    const results = FeelLinter(cm);
+
+    // then
+    expect(results).to.have.length(1);
+    expect(results[0].severity).to.eql('error');
+    expect(results[0].source).to.eql('syntaxError');
+    expect(results[0].message).to.eql('unexpected CompareOp');
+
+  });
+
+
+  it('should return 0-width syntax error', function() {
+
+    // given
+    const editor = new FeelEditor({
+      container,
+      value: '12 == 12'
+    });
+
+    const cm = editor._cmEditor;
+
+    // when
+    const results = FeelLinter(cm);
+
+    // then
+    expect(results).to.have.length(1);
+    expect(results[0].severity).to.eql('error');
+    expect(results[0].source).to.eql('syntaxError');
+    expect(results[0].message).to.eql('expression expected');
+
+  });
+
+});


### PR DESCRIPTION
Makes syntax errors visible after typing:

![image](https://user-images.githubusercontent.com/21984219/173038075-d1c7b52e-9e4c-49d5-a134-7973483aab2c.png)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
