### PR TITLE
feat(autocomplete): add variable suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ const editor = new FeelEditor({
 });
 ```
 
+### Variables
+
+You can provide a variables array that will be used for auto completion. The Variables
+need to be in the following format:
+
+```JavaScript
+const editor = new FeelEditor({
+  container,
+  variables: [
+    {
+      name: 'variablename to match',
+      detail: 'optional inline info',
+      info: 'optional pop-out info'
+    }
+  ]
+});
+```
+
 ## Hacking the Project
 
 To get the development setup make sure to have [NodeJS](https://nodejs.org/en/download/) installed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -312,6 +312,17 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@codemirror/autocomplete": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.0.3.tgz",
+      "integrity": "sha512-JTSBDC4tUyR8iRmCwQJaYpTXtOZmRn4gKjw1Fu4xIatFPqTJ7m0QRCdkdbzlvMovzjTiuHp4a8WUEB1c/LtiHg==",
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
     "@codemirror/commands": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@codemirror/autocomplete": "^6.0.3",
     "@codemirror/commands": "^6.0.0",
     "@codemirror/language": "^6.0.0",
     "@codemirror/lint": "^6.0.0",

--- a/src/autocompletion/index.js
+++ b/src/autocompletion/index.js
@@ -1,0 +1,13 @@
+import { autocompletion } from '@codemirror/autocomplete';
+
+import variables from './variables';
+
+export default function(context) {
+  return [
+    autocompletion({
+      override: [
+        variables(context),
+      ]
+    })
+  ];
+}

--- a/src/autocompletion/variables.js
+++ b/src/autocompletion/variables.js
@@ -1,0 +1,47 @@
+import { syntaxTree } from '@codemirror/language';
+
+export default variables => context => {
+  const options = variables.map(v => ({
+    label: v.name,
+    type: 'variable',
+    info: v.info,
+    detail: v.detail
+  }));
+
+  // In most cases, use what is typed before the cursor
+  let nodeBefore = syntaxTree(context.state).resolve(context.pos, -1);
+
+  // For the special case of empty nodes, we need to check the current node
+  // as well. The previous node could be part of another token, e.g.
+  // when typing functions "abs(".
+  let nextNode = nodeBefore.nextSibling;
+  const isInEmptyNode =
+        isNodeEmpty(nodeBefore) ||
+        nextNode && nextNode.from === context.pos && isNodeEmpty(nextNode);
+
+  if (context.explicit && isInEmptyNode) {
+    return {
+      from: context.pos,
+      options: options
+    };
+  }
+
+  const result = {
+    from: nodeBefore.from,
+    options: options
+  };
+
+  // Only auto-complete variables
+  if (nodeBefore.name !== 'VariableName') {
+    return null;
+  }
+
+  return result;
+};
+
+
+// helpers ///////////////////////////////
+
+function isNodeEmpty(node) {
+  return node.from === node.to;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { language } from './language';
 import { defaultKeymap } from '@codemirror/commands';
 import linter from './lint';
 import theme from './theme';
+import autocompletion from './autocompletion';
 
 /**
  * Creates a FEEL editor in the supplied container
@@ -18,6 +19,7 @@ import theme from './theme';
  */
 export default function FeelEditor({
   container,
+  variables = [],
   onChange = () => {},
   onKeyDown = () => {},
   value = '',
@@ -43,6 +45,7 @@ export default function FeelEditor({
     changeHandler,
     keyHandler,
     language(),
+    autocompletion(variables),
     theme,
     linter
   ];

--- a/test/spec/CodeEditor.spec.js
+++ b/test/spec/CodeEditor.spec.js
@@ -2,6 +2,7 @@ import FeelEditor from '../../src';
 import TestContainer from 'mocha-test-container-support';
 import { EditorSelection } from '@codemirror/state';
 import { diagnosticCount, forceLinting } from '@codemirror/lint';
+import { currentCompletions, startCompletion } from '@codemirror/autocomplete';
 
 
 const singleStart = window.__env__ && window.__env__.SINGLE_START;
@@ -25,7 +26,19 @@ return
 
     const editor = new FeelEditor({
       container,
-      value: initalValue
+      value: initalValue,
+      variables: [
+        {
+          name: 'Variable1',
+          info: 'Written in Service Task',
+          type: 'Process_1'
+        },
+        {
+          name: 'Variable2',
+          info: 'Written in Service Task',
+          type: 'Process_1'
+        }
+      ]
     });
 
     // then
@@ -251,6 +264,43 @@ return
         expect(diagnosticCount(cm.state)).to.eql(1);
         done();
       }, 0);
+
+    });
+
+  });
+
+
+  describe('autocompletion', function() {
+
+    it('should suggest applicable variables', function(done) {
+      const initalValue = 'foo';
+      const variables = [
+        { name: 'foobar' },
+        { name: 'baz' }
+      ];
+
+      const editor = new FeelEditor({
+        container,
+        value: initalValue,
+        variables
+      });
+
+      const cm = editor._cmEditor;
+
+      // move cursor to the end
+      cm.dispatch({ selection: { anchor: 3, head: 3 } });
+
+      // when
+      startCompletion(cm);
+
+      // then
+      // update done async
+      setTimeout(() => {
+        const completions = currentCompletions(cm.state);
+        expect(completions).to.have.length(1);
+        expect(completions[0].label).to.have.eql('foobar');
+        done();
+      }, 100);
 
     });
 

--- a/test/spec/autocompletion/variables.spec.js
+++ b/test/spec/autocompletion/variables.spec.js
@@ -1,0 +1,123 @@
+import { language } from '../../../src/language';
+import { EditorState } from '@codemirror/state';
+import variables from '../../../src/autocompletion/variables';
+
+describe('autocompletion - variables', function() {
+
+  it('should return variable suggestions in correct format', function() {
+
+    // given
+    const completionSource = variables([ {
+      name: 'foobar',
+      info: 'info',
+      detail: 'detail'
+    } ]);
+
+    const context = createContext('foo');
+
+    // when
+    const autoCompletion = completionSource(context);
+
+    // then
+    expect(autoCompletion).to.exist;
+    expect(autoCompletion.from).to.eql(0);
+    expect(autoCompletion.options).to.have.length(1);
+    expect(autoCompletion.options[0]).to.eql({
+      label: 'foobar',
+      type: 'variable',
+      info: 'info',
+      detail: 'detail'
+    });
+  });
+
+
+  it('should suggest for current variable', function() {
+
+    // given
+    const completionSource = variables([ { name: 'foobar' } ]);
+    const context = createContext('15 + foo');
+
+    // when
+    const autoCompletion = completionSource(context);
+
+    // then
+    expect(autoCompletion).to.exist;
+    expect(autoCompletion.from).to.eql(5);
+    expect(autoCompletion.options).to.have.length(1);
+  });
+
+
+  it('should not suggest on path expressions', function() {
+
+    // given
+    const completionSource = variables([ { name: 'foobar' } ]);
+    const context = createContext('myObject.fo', 11);
+
+    // when
+    const autoCompletion = completionSource(context);
+
+    // then
+    expect(autoCompletion).not.to.exist;
+  });
+
+
+  it('should not suggest on empty expression', function() {
+
+    // given
+    const completionSource = variables([ { name: 'foobar' } ]);
+    const context = createContext('');
+
+    // when
+    const autoCompletion = completionSource(context);
+
+    // then
+    expect(autoCompletion).not.to.exist;
+  });
+
+
+  it('should suggest on empty expression when explicitly requested', function() {
+
+    // given
+    const completionSource = variables([ { name: 'foobar' } ]);
+    const context = createContext('', true);
+
+    // when
+    const autoCompletion = completionSource(context);
+
+    // then
+    expect(autoCompletion).to.exist;
+    expect(autoCompletion.from).to.eql(0);
+  });
+
+
+  it('should suggest on empty expression when explicitly requested', function() {
+
+    // given
+    const completionSource = variables([ { name: 'foobar' } ]);
+    const context = createContext('', true);
+
+    // when
+    const autoCompletion = completionSource(context);
+
+    // then
+    expect(autoCompletion).to.exist;
+    expect(autoCompletion.from).to.eql(0);
+  });
+
+});
+
+
+// helpers /////////////////////////////
+
+function createContext(doc, explicit = false) {
+  const state = EditorState.create({
+    doc,
+    extensions: [ language() ]
+  });
+
+  return {
+    state,
+    pos:  doc.length,
+    explicit
+  };
+}


### PR DESCRIPTION
closes #3

This allows Variables to be passed for the typeahead.

![image](https://user-images.githubusercontent.com/21984219/179232458-c959ab11-7348-4371-be77-f323e25913b4.png)


try out the properties panel integration with
```
npx @bpmn-io/sr bpmn-io/bpmn-js-properties-panel#feel-editor-variables
```

![Recording 2022-07-15 at 15 28 30](https://user-images.githubusercontent.com/21984219/179232733-08009c3f-a84d-4df4-8962-1a34b2fef6e4.gif)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
