### PR TITLE
feat: add onLint callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ const editor = new FeelEditor({
   container,
   onChange,
   onKeyDown,
+  onLint,
   value
 });
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
+import { defaultKeymap } from '@codemirror/commands';
+import { setDiagnosticsEffect } from '@codemirror/lint';
 import { EditorState } from '@codemirror/state';
 import { EditorView, keymap } from '@codemirror/view';
+
+import autocompletion from './autocompletion';
 import { language } from './language';
-import { defaultKeymap } from '@codemirror/commands';
 import linter from './lint';
 import theme from './theme';
-import autocompletion from './autocompletion';
 
-import { setDiagnosticsEffect } from '@codemirror/lint';
 
 /**
  * Creates a FEEL editor in the supplied container
@@ -16,18 +17,20 @@ import { setDiagnosticsEffect } from '@codemirror/lint';
  * @param {Function} [config.onChange]
  * @param {Function} [config.onKeyDown]
  * @param {Function} [config.onLint]
+ * @param {Boolean} [config.readOnly]
  * @param {String} [config.value]
+ * @param {Array} [config.variables]
  *
  * @returns {Object} editor
  */
 export default function FeelEditor({
   container,
-  variables = [],
   onChange = () => {},
   onKeyDown = () => {},
   onLint = () => {},
+  readOnly = false,
   value = '',
-  readOnly = false
+  variables = []
 }) {
 
   const changeHandler = EditorView.updateListener.of((update) => {

--- a/test/spec/CodeEditor.spec.js
+++ b/test/spec/CodeEditor.spec.js
@@ -234,7 +234,6 @@ return
       // when
       forceLinting(cm);
 
-
       // then
       // update done async
       setTimeout(() => {
@@ -262,6 +261,64 @@ return
       // update done async
       setTimeout(() => {
         expect(diagnosticCount(cm.state)).to.eql(1);
+        done();
+      }, 0);
+
+    });
+
+
+    it('should call onLint with errors', function(done) {
+      const initalValue = '= 15';
+      const onLint = sinon.spy();
+
+      const editor = new FeelEditor({
+        container,
+        value: initalValue,
+        onLint
+      });
+
+      const cm = editor._cmEditor;
+
+      // when
+      forceLinting(cm);
+
+      // then
+      // update done async
+      setTimeout(() => {
+
+        expect(onLint).to.have.been.calledOnce;
+        expect(onLint).to.have.been.calledWith(sinon.match.array);
+        expect(onLint.args[0][0]).to.have.length(1);
+
+        done();
+      }, 0);
+
+    });
+
+
+    it('should call onLint without errors', function(done) {
+      const initalValue = '15';
+      const onLint = sinon.spy();
+
+      const editor = new FeelEditor({
+        container,
+        value: initalValue,
+        onLint
+      });
+
+      const cm = editor._cmEditor;
+
+      // when
+      forceLinting(cm);
+
+      // then
+      // update done async
+      setTimeout(() => {
+
+        expect(onLint).to.have.been.calledOnce;
+        expect(onLint).to.have.been.calledWith(sinon.match.array);
+        expect(onLint.args[0][0]).to.have.length(0);
+
         done();
       }, 0);
 


### PR DESCRIPTION
Supplies an array of lint messages to a callback function

related to https://github.com/bpmn-io/properties-panel/issues/162

Also usefull if we want to show Lint messages in the error panel in the future.
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
