### PR TITLE
feat(autocompletion): support nested variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ const editor = new FeelEditor({
 
 ### Variables
 
-You can provide a variables array that will be used for auto completion. The Variables
-need to be in the following format:
+You can provide a variables array that will be used for auto completion. Nested 
+structures are supported.  
+The Variables need to be in the following format:
 
 ```JavaScript
 const editor = new FeelEditor({
@@ -38,7 +39,13 @@ const editor = new FeelEditor({
     {
       name: 'variablename to match',
       detail: 'optional inline info',
-      info: 'optional pop-out info'
+      info: 'optional pop-out info',
+      schema: [
+        {
+          name: 'nested variable',
+          ...
+        }
+      ]
     }
   ]
 });
@@ -51,7 +58,7 @@ editor.setVariables([
   {
     name: 'newName',
     detail: 'new variable inline info',
-    info: 'new pop-out info
+    info: 'new pop-out info'
   }
 ]);
 ```

--- a/src/autocompletion/builtins.js
+++ b/src/autocompletion/builtins.js
@@ -11,9 +11,10 @@ const options = tags.map(tag => snippetCompletion(
     label: tag.name,
     type: 'function',
     info: () => {
-      const html = domify(tag.description);
+      const html = domify(`<div class="description">${tag.description}<div>`);
       return html;
-    }
+    },
+    boost: -1
   }
 ));
 

--- a/src/autocompletion/index.js
+++ b/src/autocompletion/index.js
@@ -11,7 +11,7 @@ export default function() {
       override: [
         variables,
         builtins,
-        completeFromList(snippets),
+        completeFromList(snippets.map(s => ({ ...s, boost: -1 }))),
         pathExpression
       ]
     })

--- a/src/autocompletion/index.js
+++ b/src/autocompletion/index.js
@@ -1,6 +1,7 @@
 import { autocompletion, completeFromList } from '@codemirror/autocomplete';
 import { snippets } from 'lang-feel';
 import builtins from './builtins';
+import pathExpression from './pathExpressions';
 
 import variables from './variables';
 
@@ -10,7 +11,8 @@ export default function() {
       override: [
         variables,
         builtins,
-        completeFromList(snippets)
+        completeFromList(snippets),
+        pathExpression
       ]
     })
   ];

--- a/src/autocompletion/pathExpressions.js
+++ b/src/autocompletion/pathExpressions.js
@@ -1,0 +1,95 @@
+import { syntaxTree } from '@codemirror/language';
+import { isPathExpression } from './autocompletionUtil';
+import { variablesFacet } from './VariableFacet';
+
+export default context => {
+  const variables = context.state.facet(variablesFacet)[0];
+  const nodeBefore = syntaxTree(context.state).resolve(context.pos, -1);
+
+  if (!isPathExpression(nodeBefore)) {
+    return;
+  }
+
+  const expression = findPathExpression(nodeBefore);
+
+  // if the cursor is directly after the `.`, variable starts at the cursor position
+  const from = nodeBefore === expression ? context.pos : nodeBefore.from;
+
+  const path = getPath(expression, context);
+
+  let options = variables;
+  for (var i = 0; i < path.length - 1; i++) {
+    var childVar = options.find(val => val.name === path[i].name);
+
+    if (!childVar) {
+      return null;
+    }
+
+    // only suggest if variable type matches
+    if (!!childVar.isList !== path[i].isList) {
+      return;
+    }
+
+    options = childVar.schema;
+  }
+
+  if (!options) return;
+
+  options = options.map(v => ({
+    label: v.name,
+    type: 'variable',
+    info: v.info,
+    detail: v.detail
+  }));
+
+  const result = {
+    from: from,
+    options: options
+  };
+
+  return result;
+};
+
+
+function findPathExpression(node) {
+  while (node) {
+    if (node.name === 'PathExpression') {
+      return node;
+    }
+    node = node.parent;
+  }
+}
+
+// parses the path expression into a list of variable names with type information
+// e.g. foo[0].bar => [ { name: 'foo', isList: true }, { name: 'bar', isList: false } ]
+function getPath(node, context) {
+  let path = [];
+
+  for (let child = node.firstChild; child; child = child.nextSibling) {
+    if (child.name === 'PathExpression') {
+      path.push(...getPath(child, context));
+    } else if (child.name === 'FilterExpression') {
+      path.push(...getFilter(child, context));
+    }
+    else {
+      path.push({
+        name: getNodeContent(child, context),
+        isList: false
+      });
+    }
+  }
+  return path;
+}
+
+function getFilter(node, context) {
+  const list = node.firstChild;
+
+  return [ {
+    name: getNodeContent(list, context),
+    isList: true
+  } ];
+}
+
+function getNodeContent(node, context) {
+  return context.state.sliceDoc(node.from, node.to);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,11 @@ import theme from './theme';
 
 /**
  * @typedef {object} Variable
- * @property {string} name
- * @property {string} [info]
- * @property {string} [detail]
+ * @property {string} name name or key of the variable
+ * @property {string} [info] short information about the variable, e.g. type
+ * @property {string} [detail] longer description of the variable content
+ * @property {boolean} [isList] whether the variable is a list
+ * @property {array<Variable>} [schema] array of child variables if the variable is a context or list
  */
 
 const autocompletionConf = new Compartment();

--- a/test/spec/CodeEditor.spec.js
+++ b/test/spec/CodeEditor.spec.js
@@ -32,12 +32,51 @@ return
         {
           name: 'Variable1',
           info: 'Written in Service Task',
-          type: 'Process_1'
+          detail: 'Process_1'
         },
         {
           name: 'Variable2',
           info: 'Written in Service Task',
-          type: 'Process_1'
+          detail: 'Process_1'
+        },
+        {
+          name: 'ContextVariable',
+          info: 'This is a Context Variable',
+          detail: 'Context',
+          schema: [
+            {
+              name: 'child',
+              info: 'This is a child variable',
+              detail: 'Context',
+              schema: [
+                {
+                  name: 'level2',
+                  info: 'This is a level 2 variable',
+                  detail: 'String'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          name: 'ListVariable',
+          info: 'This is a Context Variable',
+          detail: 'List',
+          isList: true,
+          schema: [
+            {
+              name: 'child',
+              info: 'This is a child variable',
+              detail: 'Context',
+              schema: [
+                {
+                  name: 'level2',
+                  info: 'This is a level 2 variable',
+                  detail: 'String'
+                }
+              ]
+            }
+          ]
         }
       ]
     });
@@ -243,12 +282,12 @@ return
           {
             name: 'Variable1',
             info: 'Written in Service Task',
-            type: 'Process_1'
+            detail: 'Process_1'
           },
           {
             name: 'Variable2',
             info: 'Written in Service Task',
-            type: 'Process_1'
+            detail: 'Process_1'
           }
         ]);
       }).not.to.throw();

--- a/test/spec/autocompletion/pathExpression.spec.js
+++ b/test/spec/autocompletion/pathExpression.spec.js
@@ -1,0 +1,160 @@
+import { language } from '../../../src/language';
+import { EditorState } from '@codemirror/state';
+import pathExpressions from '../../../src/autocompletion/pathExpressions';
+import { variablesFacet } from '../../../src/autocompletion/VariableFacet';
+
+
+describe('autocompletion - pathExpressions', function() {
+
+  describe('paths', function() {
+
+    it('should suggest on empty path', function() {
+
+      // given
+      const context = createContext('foo.', [ {
+        name: 'foo',
+        schema: [
+          {
+            name: 'bar',
+            info: 'info',
+            detail: 'detail'
+          }
+        ]
+      } ]);
+
+      // when
+      const autoCompletion = pathExpressions(context);
+
+      // then
+      expect(autoCompletion).to.exist;
+      expect(autoCompletion.from).to.eql(4);
+      expect(autoCompletion.options).to.have.length(1);
+      expect(autoCompletion.options[0]).to.eql({
+        label: 'bar',
+        type: 'variable',
+        info: 'info',
+        detail: 'detail'
+      });
+    });
+
+
+    it('should suggest while typing', function() {
+
+      // given
+      const context = createContext('foo.ba', [ {
+        name: 'foo',
+        schema: [
+          {
+            name: 'bar',
+            info: 'info',
+            detail: 'detail'
+          }
+        ]
+      } ]);
+
+      // when
+      const autoCompletion = pathExpressions(context);
+
+      // then
+      expect(autoCompletion).to.exist;
+      expect(autoCompletion.from).to.eql(4);
+      expect(autoCompletion.options).to.have.length(1);
+      expect(autoCompletion.options[0]).to.eql({
+        label: 'bar',
+        type: 'variable',
+        info: 'info',
+        detail: 'detail'
+      });
+
+    });
+
+  });
+
+
+  describe('lists', function() {
+
+    it('should suggest on empty path', function() {
+
+      // given
+      const context = createContext('foo[0].', [ {
+        name: 'foo',
+        isList: true,
+        schema: [
+          {
+            name: 'bar',
+            info: 'info',
+            detail: 'detail'
+          }
+        ]
+      } ]);
+
+      // when
+      const autoCompletion = pathExpressions(context);
+
+      // then
+      expect(autoCompletion).to.exist;
+      expect(autoCompletion.from).to.eql(7);
+      expect(autoCompletion.options).to.have.length(1);
+
+      expect(autoCompletion.options[0]).to.eql({
+        label: 'bar',
+        type: 'variable',
+        info: 'info',
+        detail: 'detail'
+      });
+    });
+
+
+    it('should suggest while typing', function() {
+
+      // given
+      const context = createContext('foo[0].ba', [ {
+        name: 'foo',
+        isList: true,
+        schema: [
+          {
+            name: 'bar',
+            info: 'info',
+            detail: 'detail'
+          }
+        ]
+      } ]);
+
+      // when
+      const autoCompletion = pathExpressions(context);
+
+      // then
+      expect(autoCompletion).to.exist;
+      expect(autoCompletion.from).to.eql(7);
+      expect(autoCompletion.options).to.have.length(1);
+      expect(autoCompletion.options[0]).to.eql({
+        label: 'bar',
+        type: 'variable',
+        info: 'info',
+        detail: 'detail'
+      });
+
+    });
+
+  });
+
+});
+
+
+// helpers /////////////////////////////
+
+function createContext(doc, variables = [], explicit = false) {
+  const state = EditorState.create({
+    doc,
+    extensions: [
+      variablesFacet.of(variables),
+      language()
+    ]
+  });
+
+  return {
+    state,
+    pos:  doc.length,
+    explicit
+  };
+}


### PR DESCRIPTION
This adds support for `pathExpression` suggestions, including `pathExpressions` with lists

![Recording 2022-11-22 at 15 30 19](https://user-images.githubusercontent.com/21984219/203340063-c30a9866-a9c3-491f-a3bc-e6f7023eeff6.gif)
