### PR TITLE
feat: allow extensions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import theme from './theme';
 
 /**
  * @typedef {object} Variable
+ * @typedef {import('@codemirror/state').Extension} Extension
  * @property {string} name name or key of the variable
  * @property {string} [info] short information about the variable, e.g. type
  * @property {string} [detail] longer description of the variable content
@@ -27,6 +28,7 @@ const autocompletionConf = new Compartment();
  *
  * @param {Object} config
  * @param {DOMNode} config.container
+ * @param {Extension[]} [config.extensions]
  * @param {DOMNode|String} [config.tooltipContainer]
  * @param {Function} [config.onChange]
  * @param {Function} [config.onKeyDown]
@@ -38,6 +40,7 @@ const autocompletionConf = new Compartment();
  * @returns {Object} editor
  */
 export default function FeelEditor({
+  extensions: editorExtensions = [],
   container,
   tooltipContainer,
   onChange = () => {},
@@ -99,7 +102,8 @@ export default function FeelEditor({
     linter,
     lintHandler,
     tooltipLayout,
-    theme
+    theme,
+    ...editorExtensions
   ];
 
   if (readOnly) {

--- a/test/spec/CodeEditor.spec.js
+++ b/test/spec/CodeEditor.spec.js
@@ -1,6 +1,7 @@
 import FeelEditor from '../../src';
 import TestContainer from 'mocha-test-container-support';
 import { EditorSelection } from '@codemirror/state';
+import { lineNumbers } from '@codemirror/view';
 import { diagnosticCount, forceLinting } from '@codemirror/lint';
 import { currentCompletions, startCompletion } from '@codemirror/autocomplete';
 import { domify } from 'min-dom';
@@ -109,6 +110,24 @@ return
     // then
     expect(editor).to.exist;
     expect(editor._cmEditor.state.doc.toString()).to.equal('Hello World!');
+  });
+
+
+  it('should allow for extensions', async function() {
+
+    // when
+    const initialValue = 'Hello World!';
+    const editor = new FeelEditor({
+      container,
+      extensions: [
+        lineNumbers()
+      ],
+      value: initialValue
+    });
+
+    // then
+    expect(editor).to.exist;
+    expect(container.querySelector('.cm-gutters')).to.exist;
   });
 
 


### PR DESCRIPTION
Closes #41

Allows to provide extensions to the code mirror instance via props. One use case is to add line numbers.

Example from the popup editor spike (https://github.com/bpmn-io/form-js/pull/708)

```js
import { lineNumbers } from '@codemirror/view';

const editor = new FeelEditor({
  container: inputRef.current,
  /* ... */
  extensions: [
    lineNumbers()
  ]
});
```
