### PR TITLE
fix(builtins): allow tabbing through arguments

### DIFF
--- a/src/autocompletion/builtins.js
+++ b/src/autocompletion/builtins.js
@@ -5,18 +5,29 @@ import { domify } from 'min-dom';
 import { isNodeEmpty, isPathExpression } from './autocompletionUtil';
 import tags from './builtins.json';
 
-const options = tags.map(tag => snippetCompletion(
-  tag.name.replace('()', '(#{1})'),
-  {
-    label: tag.name,
-    type: 'function',
-    info: () => {
-      const html = domify(`<div class="description">${tag.description}<div>`);
-      return html;
-    },
-    boost: -1
-  }
-));
+const options = tags.map(tag => {
+  const match = tag.name.match(/^([\w\s]+)\((.*)\)$/);
+  const functionName = match[1];
+  const functionArguments = match[2];
+
+  const placeHolders = functionArguments
+    .split(', ')
+    .map((arg) => `\${${arg}}`)
+    .join(', ');
+
+  return snippetCompletion(
+    `${functionName}(${placeHolders})`,
+    {
+      label: tag.name,
+      type: 'function',
+      info: () => {
+        const html = domify(`<div class="description">${tag.description}<div>`);
+        return html;
+      },
+      boost: -1
+    }
+  );
+});
 
 export default context => {
 


### PR DESCRIPTION
With https://github.com/bpmn-io/feel-editor/pull/45, the functions tags now have the arguments in them, so we need to adjust the template we add to the editor to include the relevant tab positions well.

![Recording 2023-11-02 at 11 12 40](https://github.com/bpmn-io/feel-editor/assets/21984219/985b2246-323f-484a-beb2-dd400205ee82)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
