### PR TITLE
Support dialects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ const editor = new FeelEditor({
 });
 ```
 
-Optionally, you can provide a starting document and listen for changes:
+Configure the FEEL dialect (expression or unary tests):
+
+```JavaScript
+const editor = new FeelEditor({
+  container,
+  dialect: 'unaryTests' // defaults to 'expression'
+});
+```
+
+You can provide a starting document and listen for changes:
 
 ```JavaScript
 const editor = new FeelEditor({

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ const placeholderConf = new Compartment();
  * @param {Object} config
  * @param {DOMNode} config.container
  * @param {Extension[]} [config.extensions]
+ * @param {'expression' | 'unaryTests'} [config.dialect='expression']
  * @param {DOMNode|String} [config.tooltipContainer]
  * @param {Function} [config.onChange]
  * @param {Function} [config.onKeyDown]
@@ -44,6 +45,7 @@ const placeholderConf = new Compartment();
  */
 export default function FeelEditor({
   extensions: editorExtensions = [],
+  dialect = 'expression',
   container,
   contentAttributes = {},
   tooltipContainer,
@@ -104,7 +106,9 @@ export default function FeelEditor({
     keymap.of([
       ...defaultKeymap,
     ]),
-    language(),
+    language({
+      dialect
+    }),
     linter,
     lintHandler,
     placeholderConf.of(placeholderExt(placeholder)),

--- a/src/language/index.js
+++ b/src/language/index.js
@@ -1,6 +1,10 @@
-import { LanguageSupport } from '@codemirror/language';
-import { feelLanguage } from 'lang-feel';
+import { feel } from 'lang-feel';
 
-export function language() {
-  return new LanguageSupport(feelLanguage, [ ]);
+/**
+ * @param {'expression' | 'unaryTests'} dialect
+ *
+ * @return {LanguageSupport}
+ */
+export function language(dialect) {
+  return feel(dialect);
 }

--- a/test/spec/CodeEditor.spec.js
+++ b/test/spec/CodeEditor.spec.js
@@ -133,6 +133,22 @@ return
   });
 
 
+  it('should configure <unaryTests> dialect', async function() {
+
+    // when
+    const initialValue = '"Hello", "World"';
+    const editor = new FeelEditor({
+      container,
+      value: initialValue,
+      dialect: 'unaryTests'
+    });
+
+    // then
+    expect(editor).to.exist;
+    expect(editor._cmEditor.state.doc.toString()).to.equal('"Hello", "World"');
+  });
+
+
   it('should allow for extensions', async function() {
 
     // when
@@ -516,6 +532,40 @@ return
         expect(diagnosticCount(cm.state)).to.eql(0);
         done();
       }, 0);
+
+    });
+
+
+    describe('should not highlight valid', function() {
+
+      [
+        { dialect: 'expression', value: 'Mike < 10' },
+        { dialect: 'unaryTests', value: '12, now(), "STRING"' }
+      ].forEach(({ dialect, value }) => {
+
+        it(`<${dialect}>`, function(done) {
+
+          // given
+          const editor = new FeelEditor({
+            container,
+            value,
+            dialect
+          });
+
+          const cm = getCm(editor);
+
+          // when
+          forceLinting(cm);
+
+          // then
+          // update done async
+          setTimeout(() => {
+            expect(diagnosticCount(cm.state)).to.eql(0);
+            done();
+          }, 0);
+        });
+
+      });
 
     });
 


### PR DESCRIPTION
This allows you to pass a dialect to the `feel-editor` instance, i.e. 

```JavaScript
const editor = new FeelEditor({
  container,
  dialect: 'unaryTests' // defaults to 'expression'
});
```

---

![capture JANICp_optimized](https://github.com/bpmn-io/feel-editor/assets/58601/89aed7c9-f7f9-4fd9-807b-a2a5c4de8393)

---

Child of https://github.com/bpmn-io/dmn-js/issues/880