### PR TITLE
fix: do not use `Function()`

### DIFF
--- a/src/language/index.js
+++ b/src/language/index.js
@@ -24,7 +24,7 @@ export function language(options) {
  */
 export function createContext(variables, builtins) {
   return variables.slice().reverse().reduce((context, builtin) => {
-    context[builtin.name] = new Function();
+    context[builtin.name] = () => {};
 
     return context;
   }, {});


### PR DESCRIPTION
This does not work unless `unsafe-eval` is allowed in the CSP headers

### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
