### PR TITLE
feat: make editor use full container height

### DIFF
--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -17,6 +17,9 @@ export const baseTheme = EditorView.theme({
     overflow: 'hidden',
     textOverflow: 'ellipsis'
   },
+  '&.cm-editor': {
+    height: '100%',
+  },
 
   // Don't wrap whitespace for custom HTML
   '& .cm-completionInfo > *': {

--- a/test/spec/CodeEditor.spec.js
+++ b/test/spec/CodeEditor.spec.js
@@ -173,6 +173,18 @@ return
   });
 
 
+  it('should use full container height', async function() {
+
+    // given
+    const editor = new FeelEditor({
+      container
+    });
+
+    // then
+    expect(editor._cmEditor.contentDOM.clientHeight).to.be.eq(container.clientHeight);
+  });
+
+
   describe('#getSelection', function() {
 
     it('should return selection state', function() {


### PR DESCRIPTION
### Proposed Changes

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

Related to https://github.com/camunda/camunda-modeler/issues/4342

Make the editor use full container height. It will allow it to focus when clicking anywhere in the container, not only on the text lines.

### Checklist

To ensure you provided everything we need to look at your PR:

* [X] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [X] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
