### PR TITLE
fix: complete parameterless builtins correctly

### DIFF
--- a/src/builtins/util.js
+++ b/src/builtins/util.js
@@ -25,7 +25,8 @@ export function parseBuiltin(builtin) {
   const functionName = match[1];
   const functionArguments = match[2];
 
-  const params = functionArguments.split(', ').map(name => ({ name }));
+  // parameterless function matches as empty string
+  const params = functionArguments ? functionArguments.split(', ').map(name => ({ name })) : [];
 
   return {
     name: functionName,

--- a/test/spec/autocompletion/builtin.spec.js
+++ b/test/spec/autocompletion/builtin.spec.js
@@ -38,6 +38,25 @@ describe('autocompletion - built-ins', function() {
   });
 
 
+  it('should complete parameterless builtin <now>', function() {
+
+    // given
+    const triggerCompletion = setup('now');
+
+    // when
+    const completion = triggerCompletion({ pos: 3, explicit: true });
+
+    // then
+    expect(completion).to.exist;
+
+    const nowSuggestion = completion.options.find(option => option.label.startsWith('now'));
+    expect(nowSuggestion).to.exist;
+    expect(nowSuggestion).to.include({
+      label: 'now()'
+    });
+  });
+
+
   it('should render info', function() {
 
     // given


### PR DESCRIPTION
### Proposed Changes

This makes sure we don't show non-existing params for functions like "now()" or "today()".

Related to https://github.com/bpmn-io/dmn-js/issues/898

<img width="746" alt="image" src="https://github.com/user-attachments/assets/4ab94764-ab59-4cbc-af27-85de306d079e">


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
