### PR TITLE
Support configuration of `parserDialect`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/feel-lint": "^1.3.0",
+        "@bpmn-io/feel-lint": "^1.4.0",
         "@codemirror/autocomplete": "^6.16.2",
         "@codemirror/commands": "^6.8.0",
         "@codemirror/language": "^6.10.2",
         "@codemirror/lint": "^6.8.4",
         "@codemirror/state": "^6.5.1",
         "@codemirror/view": "^6.36.2",
-        "@lezer/highlight": "^1.2.0",
-        "lang-feel": "^2.1.1",
+        "@lezer/highlight": "^1.2.1",
+        "lang-feel": "^2.3.0",
         "min-dom": "^4.2.1"
       },
       "devDependencies": {
@@ -345,32 +345,27 @@
       }
     },
     "node_modules/@bpmn-io/feel-lint": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.3.0.tgz",
-      "integrity": "sha512-wykQUqGb/wWoQI13M6T5iOPrQUwzLfI7U/SVENx3nOn634L+grQtMCULeAtF0ZVkw8wAuygIQ2m8H/mcUnWo5w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.4.0.tgz",
+      "integrity": "sha512-1bsdR/9vPD7RQVqWWPk0X0tpjLsYTDrCxIzOVtN/h32o4nPGl0dZBU5m07qaFUGD4wG3eOH4Qim1wexHG8YkBw==",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/language": "^6.10.0",
-        "lezer-feel": "^1.2.3"
+        "@codemirror/language": "^6.10.8",
+        "lezer-feel": "^1.7.0"
       },
       "engines": {
         "node": "*"
       }
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.16.2.tgz",
-      "integrity": "sha512-MjfDrHy0gHKlPWsvSsikhO1+BOh+eBHNgfH1OXs1+DAf30IonQldgMM3kxLDTG9ktE7kDLaA1j/l7KMPA4KNfw==",
+      "version": "6.18.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.4.tgz",
+      "integrity": "sha512-sFAphGQIqyQZfP2ZBsSHV7xQvo9Py0rV0dW7W3IMRdS+zDuNb2l3no78CvUaWKGfzFjI4FTrLdUSj86IGb2hRA==",
+      "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.17.0",
-        "@lezer/common": "^1.0.0"
-      },
-      "peerDependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
         "@lezer/common": "^1.0.0"
       }
     },
@@ -387,9 +382,10 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.2.tgz",
-      "integrity": "sha512-kgbTYTo0Au6dCSc/TFy7fK3fpJmgHDv1sG1KNQKJXVi+xBTEeBPY/M30YXiU6mMXeH+YIDLsbrT4ZwNRdtF+SA==",
+      "version": "6.10.8",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.8.tgz",
+      "integrity": "sha512-wcP8XPPhDH2vTqf181U8MbZnW+tDyPYy0UzVOa+oHORjyT+mhhom9vBd7dApJwoDz9Nb/a8kHjJIsuA/t8vNFw==",
+      "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -761,22 +757,25 @@
       }
     },
     "node_modules/@lezer/common": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.1.tgz",
-      "integrity": "sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+      "license": "MIT"
     },
     "node_modules/@lezer/highlight": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.0.tgz",
-      "integrity": "sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+      "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@lezer/lr": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.1.tgz",
-      "integrity": "sha512-CHsKq8DMKBf9b3yXPDIU4DbH+ZJd/sJdYOW2llbW/HudP5u0VS6Bfq1hLYfgU7uAYGFIyGGQIsSOXGPEErZiJw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+      "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -5141,16 +5140,15 @@
       }
     },
     "node_modules/lang-feel": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-2.1.1.tgz",
-      "integrity": "sha512-ib1DW52l5L43hSoIPJ6UnsBpiCSpKiKAqunMRJ/KjU9eng3Z1mm8MYTcts99vLvK0j2nDBlCp+g8L/O7ZlgIgw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-2.3.0.tgz",
+      "integrity": "sha512-cotBfyBP710udy3Tm7s4NyNZPSSLXkVV/rrfmM4NVbuzB9WGL7CbMWUzfSn6GZ+qFnh8/xbkeDHfAvPM90oENA==",
+      "license": "MIT",
       "dependencies": {
-        "@codemirror/autocomplete": "^6.16.2",
-        "@codemirror/language": "^6.10.2",
-        "@codemirror/state": "^6.4.1",
-        "@codemirror/view": "^6.28.1",
-        "@lezer/common": "^1.2.1",
-        "lezer-feel": "^1.2.9"
+        "@codemirror/autocomplete": "^6.18.4",
+        "@codemirror/language": "^6.10.8",
+        "@lezer/common": "^1.2.3",
+        "lezer-feel": "^1.7.0"
       },
       "engines": {
         "node": "*"
@@ -5170,12 +5168,14 @@
       }
     },
     "node_modules/lezer-feel": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.2.9.tgz",
-      "integrity": "sha512-YdRbOI+7BEtWxqJBztBsk8VFBTh3O9/FcYlVn9AsnNJPUwJO11Ewm2pakSA7muMtdpPC6pfsIK/YyfYgyiEMHA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.7.0.tgz",
+      "integrity": "sha512-UC8h3Nu4llRPISEUhv+Ne7bNkdxjf4+/DcU4KfO8zKxycWxev8d2BoVnGlG17zbQDtQJBD39ZQvWtjCeTFm69g==",
+      "license": "MIT",
       "dependencies": {
-        "@lezer/highlight": "^1.2.0",
-        "@lezer/lr": "^1.4.1"
+        "@lezer/highlight": "^1.2.1",
+        "@lezer/lr": "^1.4.2",
+        "min-dash": "^4.2.1"
       },
       "engines": {
         "node": "*"
@@ -8622,18 +8622,18 @@
       }
     },
     "@bpmn-io/feel-lint": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.3.0.tgz",
-      "integrity": "sha512-wykQUqGb/wWoQI13M6T5iOPrQUwzLfI7U/SVENx3nOn634L+grQtMCULeAtF0ZVkw8wAuygIQ2m8H/mcUnWo5w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.4.0.tgz",
+      "integrity": "sha512-1bsdR/9vPD7RQVqWWPk0X0tpjLsYTDrCxIzOVtN/h32o4nPGl0dZBU5m07qaFUGD4wG3eOH4Qim1wexHG8YkBw==",
       "requires": {
-        "@codemirror/language": "^6.10.0",
-        "lezer-feel": "^1.2.3"
+        "@codemirror/language": "^6.10.8",
+        "lezer-feel": "^1.7.0"
       }
     },
     "@codemirror/autocomplete": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.16.2.tgz",
-      "integrity": "sha512-MjfDrHy0gHKlPWsvSsikhO1+BOh+eBHNgfH1OXs1+DAf30IonQldgMM3kxLDTG9ktE7kDLaA1j/l7KMPA4KNfw==",
+      "version": "6.18.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.4.tgz",
+      "integrity": "sha512-sFAphGQIqyQZfP2ZBsSHV7xQvo9Py0rV0dW7W3IMRdS+zDuNb2l3no78CvUaWKGfzFjI4FTrLdUSj86IGb2hRA==",
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -8653,9 +8653,9 @@
       }
     },
     "@codemirror/language": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.2.tgz",
-      "integrity": "sha512-kgbTYTo0Au6dCSc/TFy7fK3fpJmgHDv1sG1KNQKJXVi+xBTEeBPY/M30YXiU6mMXeH+YIDLsbrT4ZwNRdtF+SA==",
+      "version": "6.10.8",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.8.tgz",
+      "integrity": "sha512-wcP8XPPhDH2vTqf181U8MbZnW+tDyPYy0UzVOa+oHORjyT+mhhom9vBd7dApJwoDz9Nb/a8kHjJIsuA/t8vNFw==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -8932,22 +8932,22 @@
       }
     },
     "@lezer/common": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.1.tgz",
-      "integrity": "sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA=="
     },
     "@lezer/highlight": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.0.tgz",
-      "integrity": "sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
       "requires": {
         "@lezer/common": "^1.0.0"
       }
     },
     "@lezer/lr": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.1.tgz",
-      "integrity": "sha512-CHsKq8DMKBf9b3yXPDIU4DbH+ZJd/sJdYOW2llbW/HudP5u0VS6Bfq1hLYfgU7uAYGFIyGGQIsSOXGPEErZiJw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
       "requires": {
         "@lezer/common": "^1.0.0"
       }
@@ -12110,16 +12110,14 @@
       }
     },
     "lang-feel": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-2.1.1.tgz",
-      "integrity": "sha512-ib1DW52l5L43hSoIPJ6UnsBpiCSpKiKAqunMRJ/KjU9eng3Z1mm8MYTcts99vLvK0j2nDBlCp+g8L/O7ZlgIgw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-2.3.0.tgz",
+      "integrity": "sha512-cotBfyBP710udy3Tm7s4NyNZPSSLXkVV/rrfmM4NVbuzB9WGL7CbMWUzfSn6GZ+qFnh8/xbkeDHfAvPM90oENA==",
       "requires": {
-        "@codemirror/autocomplete": "^6.16.2",
-        "@codemirror/language": "^6.10.2",
-        "@codemirror/state": "^6.4.1",
-        "@codemirror/view": "^6.28.1",
-        "@lezer/common": "^1.2.1",
-        "lezer-feel": "^1.2.9"
+        "@codemirror/autocomplete": "^6.18.4",
+        "@codemirror/language": "^6.10.8",
+        "@lezer/common": "^1.2.3",
+        "lezer-feel": "^1.7.0"
       }
     },
     "levn": {
@@ -12133,12 +12131,13 @@
       }
     },
     "lezer-feel": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.2.9.tgz",
-      "integrity": "sha512-YdRbOI+7BEtWxqJBztBsk8VFBTh3O9/FcYlVn9AsnNJPUwJO11Ewm2pakSA7muMtdpPC6pfsIK/YyfYgyiEMHA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.7.0.tgz",
+      "integrity": "sha512-UC8h3Nu4llRPISEUhv+Ne7bNkdxjf4+/DcU4KfO8zKxycWxev8d2BoVnGlG17zbQDtQJBD39ZQvWtjCeTFm69g==",
       "requires": {
-        "@lezer/highlight": "^1.2.0",
-        "@lezer/lr": "^1.4.1"
+        "@lezer/highlight": "^1.2.1",
+        "@lezer/lr": "^1.4.2",
+        "min-dash": "^4.2.1"
       }
     },
     "lines-and-columns": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint .",
     "pull:platform-docs": "git -C camunda-platform-docs pull || git clone git@github.com:camunda/camunda-platform-docs.git camunda-platform-docs",
     "start": "cross-env SINGLE_START=true npm run dev",
+    "start:camunda": "cross-env SINGLE_START=camunda npm run dev",
     "dev": "npm test -- --auto-watch --no-single-run",
     "prepare": "run-s build"
   },

--- a/package.json
+++ b/package.json
@@ -47,15 +47,15 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/feel-lint": "^1.3.0",
+    "@bpmn-io/feel-lint": "^1.4.0",
     "@codemirror/autocomplete": "^6.16.2",
     "@codemirror/commands": "^6.8.0",
     "@codemirror/language": "^6.10.2",
     "@codemirror/lint": "^6.8.4",
     "@codemirror/state": "^6.5.1",
     "@codemirror/view": "^6.36.2",
-    "@lezer/highlight": "^1.2.0",
-    "lang-feel": "^2.1.1",
+    "@lezer/highlight": "^1.2.1",
+    "lang-feel": "^2.3.0",
     "min-dom": "^4.2.1"
   },
   "devDependencies": {

--- a/src/core/facets.js
+++ b/src/core/facets.js
@@ -1,7 +1,8 @@
 import { Facet } from '@codemirror/state';
 
 /**
- * @typedef { 'expression' | 'unaryTests' } Dialect
+ * @typedef { import('../language').Dialect } Dialect
+ * @typedef { import('../language').ParserDialect } ParserDialect
  * @typedef { import('..').Variable } Variable
  */
 
@@ -16,6 +17,12 @@ export const builtinsFacet = Facet.define();
 export const variablesFacet = Facet.define();
 
 /**
- * @type {Facet<dialect>}
+ * @type {Facet<Dialect>}
  */
 export const dialectFacet = Facet.define();
+
+/**
+ * @type {Facet<ParserDialect>}
+ */
+export const parserDialectFacet = Facet.define();
+

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -5,6 +5,7 @@ import { createContext, language } from '../language';
 import {
   variablesFacet,
   builtinsFacet,
+  parserDialectFacet,
   dialectFacet
 } from './facets';
 
@@ -23,6 +24,7 @@ import {
 /**
  * @typedef { {
  *   dialect?: import('../language').Dialect,
+ *   parserDialect?: import('../language').ParserDialect,
  *   variables?: Variable[],
  *   builtins?: Variable[]
  * } } CoreConfig
@@ -38,6 +40,7 @@ import {
  */
 export function configure({
   dialect = 'expression',
+  parserDialect,
   variables = [],
   builtins = [],
   completions = feelCompletions({ builtins, variables })
@@ -49,8 +52,10 @@ export function configure({
     dialectFacet.of(dialect),
     builtinsFacet.of(builtins),
     variablesFacet.of(variables),
+    parserDialectFacet.of(parserDialect),
     language({
       dialect,
+      parserDialect,
       context,
       completions
     })
@@ -67,10 +72,12 @@ export function get(state) {
   const builtins = state.facet(builtinsFacet)[0];
   const variables = state.facet(variablesFacet)[0];
   const dialect = state.facet(dialectFacet)[0];
+  const parserDialect = state.facet(parserDialectFacet)[0];
 
   return {
     builtins,
     variables,
-    dialect
+    dialect,
+    parserDialect
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,11 @@ import { camunda as camundaBuiltins } from './builtins';
  */
 
 /**
+ * @typedef { import('./language').Dialect } Dialect
+ * @typedef { import('./language').ParserDialect } ParserDialect
+ */
+
+/**
  * @typedef {object} Builtin
  * @property {string} name
  * @property {string} description
@@ -33,6 +38,7 @@ const placeholderConf = new Compartment();
  * @param {DOMNode} config.container
  * @param {Extension[]} [config.extensions]
  * @param {Dialect} [config.dialect='expression']
+ * @param {ParserDialect} [config.parserDialect]
  * @param {DOMNode|String} [config.tooltipContainer]
  * @param {Function} [config.onChange]
  * @param {Function} [config.onKeyDown]
@@ -41,12 +47,11 @@ const placeholderConf = new Compartment();
  * @param {String} [config.value]
  * @param {Variable[]} [config.variables]
  * @param {Variable[]} [config.builtins]
- *
- * @returns {Object} editor
  */
 export default function FeelEditor({
   extensions: editorExtensions = [],
   dialect = 'expression',
+  parserDialect,
   container,
   contentAttributes = {},
   tooltipContainer,
@@ -101,7 +106,8 @@ export default function FeelEditor({
     coreConf.of(Core.configure({
       dialect,
       builtins,
-      variables
+      variables,
+      parserDialect
     })),
     bracketMatching(),
     indentOnInput(),
@@ -185,16 +191,12 @@ FeelEditor.prototype.getSelection = function() {
  */
 FeelEditor.prototype.setVariables = function(variables) {
 
-  const {
-    dialect,
-    builtins
-  } = Core.get(this._cmEditor.state);
+  const config = Core.get(this._cmEditor.state);
 
   this._cmEditor.dispatch({
     effects: [
       coreConf.reconfigure(Core.configure({
-        dialect,
-        builtins,
+        ...config,
         variables
       }))
     ]

--- a/src/language/index.js
+++ b/src/language/index.js
@@ -5,8 +5,13 @@ import { feel } from 'lang-feel';
  */
 
 /**
+ * @typedef { 'camunda' | undefined } ParserDialect
+ */
+
+/**
  * @param { {
  *   dialect?: Dialect,
+ *   parserDialect?: ParserDialect,
  *   context?: Record<string, any>,
  *   completions?: import('@codemirror/autocomplete').CompletionSource[]
  * } } options

--- a/test/spec/CodeEditor.spec.js
+++ b/test/spec/CodeEditor.spec.js
@@ -481,8 +481,9 @@ return
 
       [
         { dialect: 'expression', value: 'Mike < 10' },
-        { dialect: 'unaryTests', value: '12, now(), "STRING"' }
-      ].forEach(({ dialect, value }) => {
+        { dialect: 'unaryTests', value: '12, now(), "STRING"' },
+        { dialect: 'expression', value: '`a + 1`', parserDialect: 'camunda' }
+      ].forEach(({ dialect, parserDialect, value }) => {
 
         it(`<${dialect}>`, async function() {
 
@@ -490,7 +491,8 @@ return
           const editor = new FeelEditor({
             container,
             value,
-            dialect
+            dialect,
+            parserDialect
           });
 
           // when

--- a/test/spec/CodeEditor.spec.js
+++ b/test/spec/CodeEditor.spec.js
@@ -506,7 +506,7 @@ return
 
 
     it('should highlight unexpected operations', async function() {
-      const initalValue = '= 15';
+      const initalValue = '^15';
 
       const editor = new FeelEditor({
         container,
@@ -522,7 +522,7 @@ return
 
 
     it('should highlight missing operations', async function() {
-      const initalValue = '15 == 15';
+      const initalValue = '15 =^15';
 
       const editor = new FeelEditor({
         container,
@@ -541,8 +541,10 @@ return
 
       it('with errors', async function() {
 
-        const initalValue = '= 15';
-        const onLint = sinon.spy();
+        const initalValue = '^15';
+        const onLint = sinon.spy((diagnostics) => {
+          expect(diagnostics).to.have.length(1);
+        });
 
         const editor = new FeelEditor({
           container,
@@ -555,8 +557,6 @@ return
 
         // then
         expect(onLint).to.have.been.calledOnce;
-        expect(onLint).to.have.been.calledWith(sinon.match.array);
-        expect(onLint.args[0][0]).to.have.length(1);
       });
 
 

--- a/test/spec/CodeEditor.spec.js
+++ b/test/spec/CodeEditor.spec.js
@@ -19,7 +19,7 @@ describe('CodeEditor', function() {
   });
 
 
-  (singleStart ? it.only : it)('should render', async function() {
+  (singleStart && singleStart !== 'camunda' ? it.only : it)('should render', async function() {
 
     // when
     const initialValue = `for
@@ -114,6 +114,30 @@ return
             },
             {} // unnamed
           ]
+        }
+      ]
+    });
+
+    // then
+    expect(editor).to.exist;
+
+  });
+
+
+  (singleStart === 'camunda' ? it.only : it)('should render with camunda dialect', async function() {
+
+    // when
+    const initialValue = '"At Camunda, you can" + escape.`variables with backticks`';
+
+    const editor = new FeelEditor({
+      container,
+      value: initialValue,
+      parserDialect: 'camunda',
+      variables: [
+        {
+          name: 'variable with space',
+          info: 'Needs to be escaped',
+          detail: 'Process_1'
         }
       ]
     });


### PR DESCRIPTION
### Proposed Changes

Allows us to setup the editor so it recognizes different parser dialects, i.e. `camunda`, and hence recognize [backtick identifiers](https://docs.camunda.io/docs/next/components/modeler/feel/language-guide/feel-variables/#escape-variable-names) on the language level (https://github.com/nikku/lezer-feel/pull/37).

![image](https://github.com/user-attachments/assets/04e63137-c140-47a7-a874-7b6cec83f578)


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
