### PR TITLE
deps: update @bpmn-io/feel-lint to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to [@bpmn-io/feel-editor](https://github.com/bpmn-io/feel-ed
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: recognize unclosed string literal as syntax error ([nikku/lezer-feel#52](https://github.com/nikku/lezer-feel/pull/52))
+* `DEPS`: update to `@bpmn-io/feel-lint@2.0.1`
+
 ## 1.11.0
 
 * `FEAT`: update camunda built-ins (added `fromAi`) ([@camunda/feel-builtins#1](https://github.com/camunda/feel-builtins/pull/1))

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/feel-lint": "^1.4.0",
+        "@bpmn-io/feel-lint": "^2.0.1",
         "@camunda/feel-builtins": "^0.2.0",
         "@codemirror/autocomplete": "^6.16.2",
         "@codemirror/commands": "^6.8.0",
@@ -344,13 +344,13 @@
       }
     },
     "node_modules/@bpmn-io/feel-lint": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.4.0.tgz",
-      "integrity": "sha512-1bsdR/9vPD7RQVqWWPk0X0tpjLsYTDrCxIzOVtN/h32o4nPGl0dZBU5m07qaFUGD4wG3eOH4Qim1wexHG8YkBw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-2.0.1.tgz",
+      "integrity": "sha512-mvMzpckSxBjMDppyjXZyPDgjOKEwJJaWLUfV1dmDCWaJx/qyLiqSyPkRpSpmj+n51l06KHh8fpLBZxUF0zd2Lw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.10.8",
-        "lezer-feel": "^1.7.0"
+        "lezer-feel": "^1.7.1"
       },
       "engines": {
         "node": "*"
@@ -4981,9 +4981,9 @@
       }
     },
     "node_modules/lezer-feel": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.7.0.tgz",
-      "integrity": "sha512-UC8h3Nu4llRPISEUhv+Ne7bNkdxjf4+/DcU4KfO8zKxycWxev8d2BoVnGlG17zbQDtQJBD39ZQvWtjCeTFm69g==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.8.1.tgz",
+      "integrity": "sha512-g0eGi7/INNPtPbtcz5ubInc3rSvXuJI5NfmS1hVU1FkaKNdBpwWdxXzrUb4wxr8DNXhXnUs1/a9rO4HaDzII7Q==",
       "license": "MIT",
       "dependencies": {
         "@lezer/highlight": "^1.2.1",
@@ -8281,12 +8281,12 @@
       }
     },
     "@bpmn-io/feel-lint": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.4.0.tgz",
-      "integrity": "sha512-1bsdR/9vPD7RQVqWWPk0X0tpjLsYTDrCxIzOVtN/h32o4nPGl0dZBU5m07qaFUGD4wG3eOH4Qim1wexHG8YkBw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-2.0.1.tgz",
+      "integrity": "sha512-mvMzpckSxBjMDppyjXZyPDgjOKEwJJaWLUfV1dmDCWaJx/qyLiqSyPkRpSpmj+n51l06KHh8fpLBZxUF0zd2Lw==",
       "requires": {
         "@codemirror/language": "^6.10.8",
-        "lezer-feel": "^1.7.0"
+        "lezer-feel": "^1.7.1"
       }
     },
     "@camunda/feel-builtins": {
@@ -11671,9 +11671,9 @@
       }
     },
     "lezer-feel": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.7.0.tgz",
-      "integrity": "sha512-UC8h3Nu4llRPISEUhv+Ne7bNkdxjf4+/DcU4KfO8zKxycWxev8d2BoVnGlG17zbQDtQJBD39ZQvWtjCeTFm69g==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.8.1.tgz",
+      "integrity": "sha512-g0eGi7/INNPtPbtcz5ubInc3rSvXuJI5NfmS1hVU1FkaKNdBpwWdxXzrUb4wxr8DNXhXnUs1/a9rO4HaDzII7Q==",
       "requires": {
         "@lezer/highlight": "^1.2.1",
         "@lezer/lr": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@bpmn-io/feel-lint": "^1.4.0",
+    "@bpmn-io/feel-lint": "^2.0.1",
     "@camunda/feel-builtins": "^0.2.0",
     "@codemirror/autocomplete": "^6.16.2",
     "@codemirror/commands": "^6.8.0",

--- a/test/spec/CodeEditor.spec.js
+++ b/test/spec/CodeEditor.spec.js
@@ -563,6 +563,22 @@ return
     });
 
 
+    it('should highlight unclosed string literal', async function() {
+      const initialValue = '"unclosed string';
+
+      const editor = new FeelEditor({
+        container,
+        value: initialValue
+      });
+
+      // when
+      const diagnostics = await lint(editor);
+
+      // then
+      expect(diagnostics).to.eql(1);
+    });
+
+
     describe('should call onLint', function() {
 
       it('with errors', async function() {


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5190

### Proposed Changes

Update to feel-lint@2.0.0 does not require adjustment as it is using the feel language config of the editor. 

feel-lint@2.0.1 detects unclosed string literals (`"unclosed string`) 

<img width="290" height="100" alt="image" src="https://github.com/user-attachments/assets/fe94ffac-b1c5-4b40-be70-f6155d441c5c" />

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
