### PR TITLE
feat: enhance FEEL syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [@bpmn-io/feel-editor](https://github.com/bpmn-io/feel-ed
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: enhance FEEL syntax highlighting ([#100](https://github.com/bpmn-io/feel-editor/pull/100))
 * `DEPS`: update to `@camunda/feel-builtins@1.2.0`
 * `DEPS`: update to `min-dom@5.3.0`
 * `DEPS`: update `codemirror*` dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to [@bpmn-io/feel-editor](https://github.com/bpmn-io/feel-ed
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: enhance FEEL syntax highlighting ([#100](https://github.com/bpmn-io/feel-editor/pull/100))
+* `DEPS`: bump `@bpmn-io/lang-feel` to v4 ([#100](https://github.com/bpmn-io/feel-editor/pull/100))
 * `DEPS`: update to `@camunda/feel-builtins@1.2.0`
 * `DEPS`: update to `min-dom@5.3.0`
 * `DEPS`: update `codemirror*` dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.29.7",
+        "@bpmn-io/cm-theme": "^0.2.0",
         "@rollup/plugin-commonjs": "^29.0.3",
         "@rollup/plugin-json": "^6.1.0",
         "@testing-library/dom": "^10.4.0",
@@ -57,6 +58,9 @@
       },
       "engines": {
         "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@bpmn-io/cm-theme": "^0.2.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -317,6 +321,24 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bpmn-io/cm-theme": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.2.0.tgz",
+      "integrity": "sha512-uWrOWvABxvP+6g7tjVbjBXLywWe4e1uZaqQCJfm+RHxwYFRzPWDnpsn+7AMiAfCNDk8jXUDPqpnQXv93Mq6M0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.12.3",
+        "@lezer/highlight": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
       }
     },
     "node_modules/@bpmn-io/feel-lint": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",
+    "@bpmn-io/cm-theme": "^0.2.0",
     "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-json": "^6.1.0",
     "@testing-library/dom": "^10.4.0",
@@ -98,5 +99,8 @@
     "sinon-chai": "^4.0.1",
     "typescript": "^5.9.3",
     "webpack": "^5.107.2"
+  },
+  "peerDependencies": {
+    "@bpmn-io/cm-theme": "^0.2.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ import json from '@rollup/plugin-json';
 import pkg from './package.json';
 
 
-const nonbundledDependencies = Object.keys({ ...pkg.dependencies });
+const nonbundledDependencies = Object.keys({ ...pkg.dependencies, ...pkg.peerDependencies });
 
 module.exports = {
   input: pkg.source,

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,3 +1,5 @@
-import { baseTheme, highlightTheme, syntaxClasses } from './theme.js';
+import { feelLight } from '@bpmn-io/cm-theme';
 
-export default [ baseTheme, highlightTheme, syntaxClasses ];
+import { baseTheme } from './theme.js';
+
+export default [ baseTheme, feelLight ];

--- a/src/theme/theme.js
+++ b/src/theme/theme.js
@@ -1,6 +1,4 @@
-import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { EditorView } from '@codemirror/view';
-import { tags as t } from '@lezer/highlight';
 
 export const baseTheme = EditorView.theme({
   '& .cm-content': {
@@ -40,39 +38,3 @@ export const baseTheme = EditorView.theme({
     marginBottom: 0,
   }
 });
-
-export const highlightTheme = EditorView.baseTheme({
-  '& .variableName': {
-    color: '#10f'
-  },
-  '& .number': {
-    color: '#164'
-  },
-  '& .string': {
-    color: '#a11'
-  },
-  '& .bool': {
-    color: '#219'
-  },
-  '& .function': {
-    color: '#aa3731',
-    fontWeight: 'bold'
-  },
-  '& .control': {
-    color: '#708'
-  }
-});
-
-export const syntaxClasses = syntaxHighlighting(
-  HighlightStyle.define([
-    { tag: t.variableName, class: 'variableName' },
-    { tag: t.name, class: 'variableName' },
-    { tag: t.number, class: 'number' },
-    { tag: t.string, class: 'string' },
-    { tag: t.bool, class: 'bool' },
-    { tag: t.function(t.variableName), class: 'function' },
-    { tag: t.function(t.special(t.variableName)), class: 'function' },
-    { tag: t.controlKeyword, class: 'control' },
-    { tag: t.operatorKeyword, class: 'control' }
-  ])
-);


### PR DESCRIPTION
### Proposed Changes

This pull request aims to make the feel-editor syntax highlighting consistent with [variable-outline](https://github.com/bpmn-io/variable-outline/pull/96).

<img width="990" height="919" alt="image" src="https://github.com/user-attachments/assets/0601fac8-2675-40be-9ecf-bbf731fe78e5" />


<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
