### PR TITLE
Fix snippet completions in path and with prefix / bump to `@bpmn-io/lang-feel@4.0.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable changes to [@bpmn-io/feel-editor](https://github.com/bpmn-io/feel-ed
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: enhance FEEL syntax highlighting ([#100](https://github.com/bpmn-io/feel-editor/pull/100))
-* `DEPS`: bump `@bpmn-io/lang-feel` to v4 ([#100](https://github.com/bpmn-io/feel-editor/pull/100))
+* `FIX`: correct snippet completions in path segment ([#105](https://github.com/bpmn-io/feel-editor/pull/105))
+* `FIX`: correct snippet completions from prefix ([#105](https://github.com/bpmn-io/feel-editor/pull/105))
+* `DEPS`: update to `@bpmn-io/lang-feel@4.0.2`
 * `DEPS`: update to `@camunda/feel-builtins@1.2.0`
 * `DEPS`: update to `min-dom@5.3.0`
 * `DEPS`: update `codemirror*` dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-lint": "^3.1.0",
-        "@bpmn-io/lang-feel": "^4.0.0",
+        "@bpmn-io/lang-feel": "^4.0.2",
         "@camunda/feel-builtins": "^1.2.0",
         "@codemirror/autocomplete": "^6.20.0",
         "@codemirror/commands": "^6.10.3",
@@ -355,13 +355,13 @@
       }
     },
     "node_modules/@bpmn-io/lang-feel": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feel/-/lang-feel-4.0.0.tgz",
-      "integrity": "sha512-QzeIJ4fSSPIqGMSiW/FM/Pv+rP+kKO+6DtndNQYWO3EzmhNOy4IM3S9HKlTmjPHWw6Yj2FJhYE5tTavA7tfZQQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feel/-/lang-feel-4.0.2.tgz",
+      "integrity": "sha512-rTPeJ77/2nYKbJXpvDmrNXy+opoIpD3Rsch0grCUZAO6xF68r41QeV8SqOdr2yZxD/4gI6YXlQhqh4rqFRDJXA==",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/lezer-feel": "^3.0.0",
-        "@codemirror/autocomplete": "^6.20.1",
+        "@bpmn-io/lezer-feel": "^3.0.1",
+        "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/language": "^6.12.3",
         "@lezer/common": "^1.5.2"
       },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "license": "MIT",
   "dependencies": {
     "@bpmn-io/feel-lint": "^3.1.0",
-    "@bpmn-io/lang-feel": "^4.0.0",
+    "@bpmn-io/lang-feel": "^4.0.2",
     "@camunda/feel-builtins": "^1.2.0",
     "@codemirror/autocomplete": "^6.20.0",
     "@codemirror/commands": "^6.10.3",

--- a/src/autocompletion/index.js
+++ b/src/autocompletion/index.js
@@ -1,8 +1,7 @@
-import { snippets, keywordCompletions } from '@bpmn-io/lang-feel';
-import { completeFromList } from '@codemirror/autocomplete';
-
+import { keywordCompletions } from '@bpmn-io/lang-feel';
 import { pathExpressionCompletion } from './pathExpression.js';
 import { variableCompletion } from './variable.js';
+import { snippetCompletions } from './snippets.js';
 
 /**
  * @typedef { import('../core').Variable } Variable
@@ -22,7 +21,7 @@ export function completions({ variables = [], builtins = [] }) {
   return [
     pathExpressionCompletion({ variables }),
     variableCompletion({ variables, builtins }),
-    completeFromList(snippets),
+    snippetCompletions(),
     ...keywordCompletions
   ];
 }

--- a/src/autocompletion/snippets.js
+++ b/src/autocompletion/snippets.js
@@ -1,0 +1,13 @@
+import { snippets, snippetCompletion } from '@bpmn-io/lang-feel';
+
+/**
+ * A completion source for snippets, including:
+ *
+ *   * Structural snippets (for, if, function, …)
+ *   * Literal keywords (true, false, null)
+ *
+ * @return {import('@codemirror/autocomplete').CompletionSource}
+ */
+export function snippetCompletions() {
+  return snippetCompletion(snippets);
+}

--- a/src/autocompletion/variable.js
+++ b/src/autocompletion/variable.js
@@ -37,6 +37,10 @@ export function variableCompletion({ variables = [], builtins = [] }) {
     const nodeBefore = syntaxTree(state).resolve(pos, -1);
 
     if (isEmpty(nodeBefore, pos)) {
+      if (isPathExpression(nodeBefore)) {
+        return null;
+      }
+
       return context.explicit ? {
         from: pos,
         options,

--- a/test/spec/CodeEditor.spec.js
+++ b/test/spec/CodeEditor.spec.js
@@ -845,8 +845,58 @@ return
         const completions = currentCompletions(cm.state);
         expect(completions[0].label).to.eql('for');
       });
+    });
+
+
+    it('should complete property after pathname', function() {
+      const initialValue = 'ContextVariable.child.';
+      const variables = [
+        {
+          name: 'ContextVariable',
+          info: 'This is a Context Variable',
+          detail: 'Context',
+          entries: [
+            {
+              name: 'child',
+              info: 'This is a child variable',
+              detail: 'Context',
+              entries: [
+                {
+                  name: 'level2',
+                  info: 'This is a level 2 variable',
+                  detail: 'String'
+                }
+              ]
+            }
+          ]
+        }
+      ];
+
+      const editor = new FeelEditor({
+        container,
+        value: initialValue,
+        variables
+      });
+
+      const cm = getCm(editor);
+
+      // move cursor to the end
+      select(cm, 22);
+
+      // when
+      startCompletion(cm);
+
+      // then
+      // update done async
+      return expectEventually(() => {
+        const completions = currentCompletions(cm.state);
+
+        expect(completions).to.have.length(1);
+        expect(completions[0].label).to.eql('level2');
+      });
 
     });
+
 
     it('should complete literals', function() {
       const initialValue = 'tr';
@@ -872,10 +922,37 @@ return
         const completions = currentCompletions(cm.state);
 
         // true should at least be shown, not necessarily first
-        expect(completions.find(c=>c.label === 'true')).to.exist;
+        expect(completions.find(c => c.label === 'true')).to.exist;
 
       });
 
+    });
+
+
+    it('should complete <function> snippet in expression context', function() {
+
+      // 'function' is a FEEL keyword parsed as FunctionDefinition (not Identifier),
+      // so ifExpression fires and structural snippets are offered
+      const initialValue = 'a + function';
+
+      const editor = new FeelEditor({
+        container,
+        value: initialValue
+      });
+
+      const cm = getCm(editor);
+
+      // move cursor to the end
+      select(cm, 12);
+
+      // when
+      startCompletion(cm);
+
+      // then
+      return expectEventually(() => {
+        const completions = currentCompletions(cm.state);
+        expect(completions.find(c => c.label === 'function')).to.exist;
+      });
     });
 
 

--- a/test/spec/autocompletion/builtin.spec.js
+++ b/test/spec/autocompletion/builtin.spec.js
@@ -140,6 +140,49 @@ describe('autocompletion - built-ins', function() {
   });
 
 
+  it('should not complete path expression path name', function() {
+
+    // given
+    const triggerCompletion = setup('myObject.fo', [ { name: 'foobar' } ]);
+
+    // when
+    const completion = triggerCompletion();
+
+    // then
+    expect(completion).not.to.exist;
+  });
+
+
+  describe('should not complete path expression after dot', function() {
+
+    it('active', function() {
+
+      // given
+      const triggerCompletion = setup('myObject.foo.', [ { name: 'bar' } ]);
+
+      // when
+      const completion = triggerCompletion();
+
+      // then
+      expect(completion).not.to.exist;
+    });
+
+
+    it('explicit', function() {
+
+      // given
+      const triggerCompletion = setup('myObject.foo.', [ { name: 'bar' } ]);
+
+      // when
+      const completion = triggerCompletion({ explicit: true });
+
+      // then
+      expect(completion).not.to.exist;
+    });
+
+  });
+
+
   it('should complete when explicitly requested', function() {
 
     // given

--- a/test/spec/autocompletion/pathExpression.spec.js
+++ b/test/spec/autocompletion/pathExpression.spec.js
@@ -42,6 +42,41 @@ describe('autocompletion - pathExpression', function() {
     });
 
 
+    it('should complete on nested empty path', function() {
+
+      // given
+      const triggerCompletion = setup('foo.bar.', [ {
+        name: 'foo',
+        entries: [
+          {
+            name: 'bar',
+            entries: [
+              {
+                name: 'other',
+                info: 'info',
+                detail: 'detail'
+              }
+            ]
+          }
+        ]
+      } ]);
+
+      // when
+      const completion = triggerCompletion();
+
+      // then
+      expect(completion).to.exist;
+      expect(completion.from).to.eql(8);
+      expect(completion.options).to.have.length(1);
+      expect(completion.options[0]).to.eql({
+        label: 'other',
+        type: 'variable',
+        info: 'info',
+        detail: 'detail'
+      });
+    });
+
+
     it('should complete while typing', function() {
 
       // given

--- a/test/spec/autocompletion/snippet.spec.js
+++ b/test/spec/autocompletion/snippet.spec.js
@@ -1,0 +1,150 @@
+import {
+  configure as feelCore
+} from '../../../src/core/index.js';
+
+import { EditorState } from '@codemirror/state';
+import { CompletionContext } from '@codemirror/autocomplete';
+import { snippetCompletions } from '../../../src/autocompletion/snippets.js';
+
+import { expect } from 'chai';
+
+
+describe('autocompletion - snippets', function() {
+
+  it('should complete empty', async function() {
+
+    // given
+    const triggerCompletion = setup('');
+
+    // when
+    const completion = await triggerCompletion({ explicit: true });
+
+    // then
+    expect(completion).to.exist;
+    expect(completion.from).to.eql(0);
+    expect(completion.options).to.have.length(9);
+    expect(completion.options[0]).to.include({
+      label: 'function',
+      type: 'keyword',
+      detail: 'definition'
+    });
+  });
+
+
+  it('should complete arithmetic expression', async function() {
+
+    // given
+    const triggerCompletion = setup('a + ');
+
+    // when
+    const completion = await triggerCompletion({ pos: 3, explicit: true });
+
+    // then
+    expect(completion).to.exist;
+    expect(completion.from).to.eql(3);
+    expect(completion.options).to.have.length(9);
+    expect(completion.options[0]).to.include({
+      label: 'function',
+      type: 'keyword',
+      detail: 'definition'
+    });
+  });
+
+
+  it('should complete partial', async function() {
+
+    // given
+    const triggerCompletion = setup('n');
+
+    // when
+    const completion = await triggerCompletion({ pos: 1 });
+
+    // then
+    expect(completion).to.exist;
+    expect(completion.from).to.eql(0);
+    expect(completion.options).to.have.length(9);
+    expect(completion.options[0]).to.include({
+      label: 'function',
+      type: 'keyword',
+      detail: 'definition'
+    });
+  });
+
+
+  it('should not complete in path expression path name', async function() {
+
+    // given
+    const triggerCompletion = setup('myObject.nu');
+
+    // when
+    const completion = await triggerCompletion();
+
+    // then
+    expect(completion).not.to.exist;
+  });
+
+
+  describe('should not complete in path expression after dot', function() {
+
+    it('active', async function() {
+
+      // given
+      const triggerCompletion = setup('myObject.foo.');
+
+      // when
+      const completion = await triggerCompletion();
+
+      // then
+      expect(completion).not.to.exist;
+    });
+
+
+    it('explicit', async function() {
+
+      // given
+      const triggerCompletion = setup('myObject.foo.');
+
+      // when
+      const completion = await triggerCompletion({ explicit: true });
+
+      // then
+      expect(completion).not.to.exist;
+    });
+
+  });
+
+});
+
+
+// helpers /////////////////////////////
+
+/**
+ * @typedef { import('@codemirror/autocomplete').CompletionResult } CompletionResult
+ *
+ * @typedef { (options?: { pos?: number, explicit?: boolean }) => CompletionResult | null | Promise<CompletionResult | null> } CompleteFn
+ */
+
+/**
+ * @param {string} doc
+ *
+ * @return { CompleteFn }
+ */
+function setup(doc) {
+
+  const completion = snippetCompletions();
+
+  const state = EditorState.create({
+    doc,
+    extensions: [
+      feelCore({
+        completions: [
+          completion
+        ]
+      })
+    ]
+  });
+
+  return ({ pos = doc.length, explicit = false } = { }) => {
+    return completion(new CompletionContext(state, pos, explicit));
+  };
+}

--- a/test/spec/autocompletion/variable.spec.js
+++ b/test/spec/autocompletion/variable.spec.js
@@ -95,7 +95,7 @@ describe('autocompletion - variable', function() {
   });
 
 
-  it('should not complete path expression', function() {
+  it('should not complete path expression path name', function() {
 
     // given
     const triggerCompletion = setup('myObject.fo', [ { name: 'foobar' } ]);
@@ -105,6 +105,36 @@ describe('autocompletion - variable', function() {
 
     // then
     expect(completion).not.to.exist;
+  });
+
+
+  describe('should not complete path expression after dot', function() {
+
+    it('active', function() {
+
+      // given
+      const triggerCompletion = setup('myObject.foo.', [ { name: 'foobar' } ]);
+
+      // when
+      const completion = triggerCompletion();
+
+      // then
+      expect(completion).not.to.exist;
+    });
+
+
+    it('explicit', function() {
+
+      // given
+      const triggerCompletion = setup('myObject.foo.', [ { name: 'bar' } ]);
+
+      // when
+      const completion = triggerCompletion({ explicit: true });
+
+      // then
+      expect(completion).not.to.exist;
+    });
+
   });
 
 


### PR DESCRIPTION
### Proposed Changes

Improves auto completion of snippets (both structural and literal snippets):

<img width="1059" height="428" alt="capture V26SHi_optimized" src="https://github.com/user-attachments/assets/af621a0e-07e6-4148-9519-cdab06796d19" />

* Snippets now complete on partial tokens -> `n` completes to `null`, `fun` completes to `function`
* Snippets are not proposed for path expression -> `a.` no longer proposes `if`, `function`, ...

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
