### PR TITLE
feat: support engine-version compatibility linting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/cm-theme": "^0.2.2",
-        "@bpmn-io/feel-lint": "^3.1.0",
+        "@bpmn-io/feel-lint": "^3.2.0",
         "@bpmn-io/lang-feel": "^4.0.2",
-        "@camunda/feel-builtins": "^1.2.0",
+        "@camunda/feel-builtins": "^1.4.0",
         "@codemirror/autocomplete": "^6.20.0",
         "@codemirror/commands": "^6.10.3",
         "@codemirror/language": "^6.11.3",
@@ -338,13 +338,28 @@
         "@codemirror/view": "^6.0.0"
       }
     },
-    "node_modules/@bpmn-io/feel-lint": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-3.1.0.tgz",
-      "integrity": "sha512-nOCYWMXgwR0joU4XKhu4f3P5f4/AsmuyiV1e+fzcXTCh7iMLU8VYdHXSIzZuJ0zxz3Gsnp7A8S8lt+HJ43H6IA==",
+    "node_modules/@bpmn-io/feel-analyzer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-analyzer/-/feel-analyzer-0.5.0.tgz",
+      "integrity": "sha512-g1H9MMkVH94fl0Hz2MiZ+AU2hnVTL+qsz8MvXx9xz+lBgBSp3tY342Vrxrzt36H8QqE4fn9noJc1emNA9BE3Dg==",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/lezer-feel": "^2.1.0",
+        "@bpmn-io/lezer-feel": "^3.0.1",
+        "@lezer/common": "^1.5.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@bpmn-io/feel-lint": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-3.2.0.tgz",
+      "integrity": "sha512-f9xe7VNjdZ0kDzWeALmDEWXm7KtAzVSeLVESAhBZGxTbyGzbTGubRfl2cXMN+E/U0oFEcQDuxF0A1tD02DXiLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/feel-analyzer": "^0.5.0",
+        "@bpmn-io/lezer-feel": "^3.0.0",
+        "@bpmn-io/semver-compat": "^0.1.0",
         "@codemirror/language": "^6.12.1"
       },
       "engines": {
@@ -366,7 +381,7 @@
         "node": ">= 20.12.0"
       }
     },
-    "node_modules/@bpmn-io/lang-feel/node_modules/@bpmn-io/lezer-feel": {
+    "node_modules/@bpmn-io/lezer-feel": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-3.0.1.tgz",
       "integrity": "sha512-+wWg4DP2h8WOEQx2Bz51blsw9dCqKj3kIDKYccABuoAEhzZeDhmm0A2k4ANmm9lf0w5pJmVSYz2djtrbzOvzzA==",
@@ -380,24 +395,31 @@
         "node": ">= 20.12.0"
       }
     },
-    "node_modules/@bpmn-io/lezer-feel": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.1.0.tgz",
-      "integrity": "sha512-cvNlgSYlcgFq5hfJpe6R0FD/GbkDox/9Jv8WeLIjCsgmbC9JrrzZcUQ5VrEsbTkznGFtP4vM38k4uGRuKrjffg==",
+    "node_modules/@bpmn-io/semver-compat": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/semver-compat/-/semver-compat-0.1.0.tgz",
+      "integrity": "sha512-hIcW42Ku92MUioL6aknDbRoW1jK8ZEqIe8qZZ+d3cjitDO+PMEFFXj/sezJYIHMe8elu4CBz9qpjkV8WIVG9qw==",
       "license": "MIT",
       "dependencies": {
-        "@lezer/highlight": "^1.2.3",
-        "@lezer/lr": "^1.4.7",
-        "min-dash": "^5.0.0"
+        "semver": "^7.7.2"
+      }
+    },
+    "node_modules/@bpmn-io/semver-compat/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">= 20.12.0"
+        "node": ">=10"
       }
     },
     "node_modules/@camunda/feel-builtins": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-1.2.0.tgz",
-      "integrity": "sha512-dtfv9TSDiTEivARL2l8qawxsQi9BBajoSUQQIlVXVBwt5rp/FQ9UD2DTzki//RnLnu2V2O69SxGZDhWTT28qQg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-1.4.0.tgz",
+      "integrity": "sha512-G3jH5MRvF/3L9/h6fY1zn+kwgYgH7APa84p34jajSG9IVWPCIGpttVGyRTrnbsCI76C2QdPbR2AvOm3RaLzUJg==",
       "license": "MIT"
     },
     "node_modules/@codemirror/autocomplete": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@bpmn-io/cm-theme": "^0.2.2",
         "@bpmn-io/feel-lint": "^3.2.0",
         "@bpmn-io/lang-feel": "^4.0.2",
+        "@bpmn-io/semver-compat": "^0.1.0",
         "@camunda/feel-builtins": "^1.4.0",
         "@codemirror/autocomplete": "^6.20.0",
         "@codemirror/commands": "^6.10.3",

--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
   "license": "MIT",
   "dependencies": {
     "@bpmn-io/cm-theme": "^0.2.2",
-    "@bpmn-io/feel-lint": "^3.1.0",
+    "@bpmn-io/feel-lint": "^3.2.0",
     "@bpmn-io/lang-feel": "^4.0.2",
-    "@camunda/feel-builtins": "^1.2.0",
+    "@camunda/feel-builtins": "^1.4.0",
     "@codemirror/autocomplete": "^6.20.0",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/language": "^6.11.3",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@bpmn-io/cm-theme": "^0.2.2",
     "@bpmn-io/feel-lint": "^3.2.0",
     "@bpmn-io/lang-feel": "^4.0.2",
+    "@bpmn-io/semver-compat": "^0.1.0",
     "@camunda/feel-builtins": "^1.4.0",
     "@codemirror/autocomplete": "^6.20.0",
     "@codemirror/commands": "^6.10.3",

--- a/src/core/facets.js
+++ b/src/core/facets.js
@@ -26,3 +26,8 @@ export const dialectFacet = Facet.define();
  */
 export const parserDialectFacet = Facet.define();
 
+/**
+ * @type {Facet<Record<string, string>>}
+ */
+export const enginesFacet = Facet.define();
+

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -2,11 +2,14 @@ import { completions as feelCompletions } from '../autocompletion/index.js';
 
 import { createContext, language } from '../language/index.js';
 
+import lintExtension from '../lint/index.js';
+
 import {
   variablesFacet,
   builtinsFacet,
   parserDialectFacet,
-  dialectFacet
+  dialectFacet,
+  enginesFacet
 } from './facets.js';
 
 
@@ -26,7 +29,8 @@ import {
  *   dialect?: import('../language').Dialect,
  *   parserDialect?: import('../language').ParserDialect,
  *   variables?: Variable[],
- *   builtins?: Variable[]
+ *   builtins?: Variable[],
+ *   engines?: Record<string, string>
  * } } CoreConfig
  *
  * @typedef { import('@codemirror/autocomplete').CompletionSource } CompletionSource
@@ -43,6 +47,7 @@ export function configure({
   parserDialect,
   variables = [],
   builtins = [],
+  engines,
   completions = feelCompletions({ builtins, variables })
 }) {
 
@@ -53,11 +58,16 @@ export function configure({
     builtinsFacet.of(builtins),
     variablesFacet.of(variables),
     parserDialectFacet.of(parserDialect),
+    enginesFacet.of(engines),
     language({
       dialect,
       parserDialect,
       context,
       completions
+    }),
+    lintExtension({
+      builtins,
+      engines
     })
   ];
 }
@@ -73,11 +83,13 @@ export function get(state) {
   const variables = state.facet(variablesFacet)[0];
   const dialect = state.facet(dialectFacet)[0];
   const parserDialect = state.facet(parserDialectFacet)[0];
+  const engines = state.facet(enginesFacet)[0];
 
   return {
     builtins,
     variables,
     dialect,
-    parserDialect
+    parserDialect,
+    engines
   };
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,3 +1,5 @@
+import { isCompatible } from '@bpmn-io/semver-compat';
+
 import { completions as feelCompletions } from '../autocompletion/index.js';
 
 import { createContext, language } from '../language/index.js';
@@ -22,6 +24,7 @@ import {
  * @property {Array<Variable>} [entries] array of child variables if the variable is a context or list
  * @property {'function'|'variable'} [type] type of the variable
  * @property {Array<{name: string, type?: string}>} [params] function parameters
+ * @property {Record<string, string>} [engines] engine version requirements, e.g. `{ camunda: '>=8.9' }`
  */
 
 /**
@@ -48,10 +51,17 @@ export function configure({
   variables = [],
   builtins = [],
   engines,
-  completions = feelCompletions({ builtins, variables })
+  completions
 }) {
 
+  // parse + lint against ALL built-ins so incompatible calls still parse and
+  // get flagged; only suggest the ones available in the target engine(s)
   const context = createContext([ ...variables, ...builtins ]);
+
+  const completionSources = completions ?? feelCompletions({
+    builtins: availableBuiltins(builtins, engines),
+    variables
+  });
 
   return [
     dialectFacet.of(dialect),
@@ -63,13 +73,30 @@ export function configure({
       dialect,
       parserDialect,
       context,
-      completions
+      completions: completionSources
     }),
     lintExtension({
       builtins,
       engines
     })
   ];
+}
+
+/**
+ * Built-ins available in the target engine(s); when no engines are configured,
+ * all built-ins are available.
+ *
+ * @param {Variable[]} builtins
+ * @param {Record<string, string>} [engines]
+ *
+ * @return {Variable[]}
+ */
+function availableBuiltins(builtins, engines) {
+  if (!engines || !Object.keys(engines).length) {
+    return builtins;
+  }
+
+  return builtins.filter(builtin => !builtin.engines || isCompatible(builtin.engines, engines));
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,6 @@ import { EditorView, keymap, placeholder as placeholderExt, tooltips } from '@co
 
 import mitt from 'mitt';
 
-import linter from './lint/index.js';
 import theme from './theme/index.js';
 
 import * as Core from './core/index.js';
@@ -43,6 +42,7 @@ const placeholderConf = new Compartment();
  * @param {String} [config.value]
  * @param {Variable[]} [config.variables]
  * @param {Variable[]} [config.builtins]
+ * @param {Record<string, string>} [config.engines] target engine versions (e.g. `{ camunda: '8.6' }`); enables built-in compatibility linting
  * @param {Object} [config.contentAttributes]
  * @param {String} [config.placeholder]
  */
@@ -60,7 +60,8 @@ export default function FeelEditor({
   readOnly = false,
   value = '',
   builtins = domifiedBuiltins,
-  variables = []
+  variables = [],
+  engines
 }) {
 
   this._events = mitt();
@@ -107,7 +108,8 @@ export default function FeelEditor({
       dialect,
       builtins,
       variables,
-      parserDialect
+      parserDialect,
+      engines
     })),
     bracketMatching(),
     indentOnInput(),
@@ -118,7 +120,6 @@ export default function FeelEditor({
     keymap.of([
       ...defaultKeymap,
     ]),
-    linter,
     lintHandler,
     tooltipLayout,
     placeholderConf.of(placeholderExt(placeholder)),
@@ -215,6 +216,25 @@ FeelEditor.prototype.setVariables = function(variables) {
       coreConf.reconfigure(Core.configure({
         ...config,
         variables
+      }))
+    ]
+  });
+};
+
+/**
+ * Set the target engine versions used for built-in compatibility linting.
+ *
+ * @param {Record<string, string>} engines e.g. `{ camunda: '8.6' }`
+ */
+FeelEditor.prototype.setEngines = function(engines) {
+
+  const config = Core.get(this._cmEditor.state);
+
+  this._cmEditor.dispatch({
+    effects: [
+      coreConf.reconfigure(Core.configure({
+        ...config,
+        engines
       }))
     ]
   });

--- a/src/lint/index.js
+++ b/src/lint/index.js
@@ -1,4 +1,26 @@
 import { cmFeelLinter } from '@bpmn-io/feel-lint';
 import { linter } from '@codemirror/lint';
 
-export default [ linter(cmFeelLinter()) ];
+/**
+ * Build the FEEL lint extension. Passing `engines` enables version-compatibility
+ * linting of built-in functions (in addition to the always-on syntax linting).
+ *
+ * `engines` is passed through as-is (e.g. `{ camunda: '8.6' }`); the editor is
+ * agnostic to which engines are checked.
+ *
+ * @param { {
+ *   builtins?: import('../core').Variable[],
+ *   engines?: Record<string, string>,
+ * } } [config]
+ *
+ * @return {import('@codemirror/state').Extension}
+ */
+export default function lintExtension({
+  builtins = [],
+  engines
+} = {}) {
+  return linter(cmFeelLinter({
+    builtins,
+    engines
+  }));
+}

--- a/test/spec/CodeEditor.spec.js
+++ b/test/spec/CodeEditor.spec.js
@@ -25,13 +25,17 @@ describe('CodeEditor', function() {
 
     // when
     const initialValue = `for
-  fruit in [ "apple", "bananas" ], vegetable in vegetables
+  fruit in from json("[ \\"apple\\", \\"bananas\\" ]"), vegetable in vegetables
 return
   { ingredients: [ fruit, vegetable ] }`;
 
+    const editorContainer = domify('<div style="height: 200px; border: 1px solid #ccc;"></div>');
+    container.appendChild(editorContainer);
+
     const editor = new FeelEditor({
-      container,
+      container: editorContainer,
       value: initialValue,
+      engines: { camunda: '8.9' },
       variables: [
         {
           name: 'Variable1',
@@ -121,6 +125,30 @@ return
         }
       ]
     });
+
+    const versionControl = domify(`
+      <div style="margin: 10px 0; font-family: sans-serif; font-size: 13px;">
+        <label>Camunda version for linting:
+          <select class="engine-version">
+            <option>8.6</option>
+            <option>8.7</option>
+            <option>8.8</option>
+            <option selected>8.9</option>
+            <option>8.10</option>
+          </select>
+        </label>
+      </div>
+    `);
+
+    const versionSelect = /** @type {HTMLSelectElement} */ (
+      versionControl.querySelector('.engine-version')
+    );
+
+    versionSelect.addEventListener('change', () => {
+      editor.setEngines({ camunda: versionSelect.value });
+    });
+
+    container.appendChild(versionControl);
 
     // then
     expect(editor).to.exist;

--- a/test/spec/CodeEditor.spec.js
+++ b/test/spec/CodeEditor.spec.js
@@ -36,6 +36,14 @@ return
       container: editorContainer,
       value: initialValue,
       engines: { camunda: '8.9' },
+      builtins: [
+        {
+          name: 'from json',
+          type: 'function',
+          params: [ { name: 'value' } ],
+          engines: { camunda: '>=8.9' }
+        }
+      ],
       variables: [
         {
           name: 'Variable1',
@@ -846,6 +854,42 @@ return
         expect(completions[1].label).to.eql('abs(n)');
       });
 
+    });
+
+
+    it('should not complete built-ins incompatible with the target engine', async function() {
+      const editor = new FeelEditor({
+        container,
+        value: '',
+        engines: { camunda: '8.6' },
+        builtins: [
+          {
+            name: 'now',
+            type: 'function',
+            params: []
+          },
+          {
+            name: 'from json',
+            type: 'function',
+            params: [ { name: 'value' } ],
+            engines: { camunda: '>=8.9' }
+          }
+        ]
+      });
+
+      const cm = getCm(editor);
+
+      // when
+      startCompletion(cm);
+
+      // then
+      // update done async
+      return expectEventually(() => {
+        const labels = currentCompletions(cm.state).map(completion => completion.label);
+
+        expect(labels).to.include('now()');
+        expect(labels.some(label => label.startsWith('from json'))).to.be.false;
+      });
     });
 
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5735

### Proposed Changes

Lint FEEL functions based on compatibility with Camunda (or other engine) version.

Adds an optional `engines` editor option and a `setEngines()` method that flag built-in functions unavailable in the target engine version.

#### Editor linting

An incompatible function is underlined in the editor with a warning message.

<img width="660" alt="image" src="https://github.com/user-attachments/assets/2aa870ce-3061-438d-81a7-839e37463778" />

#### Autocompletion

Autocompletion filters out incompatible functions.

<img width="660" alt="feel-editor-autocompl" src="https://github.com/user-attachments/assets/773e5b72-490c-4d87-acea-2b1eb0adfa8c" />

### Steps to try out

`npm start`

In the example, "from json" function is configured to be compatible with Camunda >= 8.9.

You the dropdown to change Camunda versions.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
